### PR TITLE
Add New Canvas button that clears graph and resets save handle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
   type Node,
   type Edge,
@@ -18,6 +18,7 @@ import { NodeDefinitionsContext } from './contexts/NodeDefinitionsContext';
 import { NodeCatalog } from './components/NodeCatalog';
 import { ExportGraphButton } from './components/NodeExport';
 import { ImportGraphButton } from './components/NodeImport';
+import { NewGraphButton } from './components/NodeNew';
 import { SaveGraphButton } from './components/NodeSave';
 import { GenericNode } from './components/nodes/GenericNode';
 import { Inspector } from './components/Inspector';
@@ -28,6 +29,9 @@ function App() {
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const reactFlowInstance = useReactFlow();
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+  // Shared file handle for Save — lifted here so "New" can reset it,
+  // matching the Word "New → Save prompts again" behavior.
+  const saveFileHandleRef = useRef<FileSystemFileHandle | null>(null);
 
   // Build nodeTypes map dynamically from definitions — every type uses GenericNode
   const nodeTypes = useMemo(() => {
@@ -172,6 +176,15 @@ function App() {
     setSelectedNode(null);
   }, [setNodes, setEdges, handleNodeDataChange]);
 
+  const handleNewGraph = useCallback(() => {
+    setNodes([]);
+    setEdges([]);
+    setSelectedNode(null);
+    // Forget the previously-picked save location so the next Save opens the
+    // file picker again (fresh canvas = fresh file).
+    saveFileHandleRef.current = null;
+  }, [setNodes, setEdges]);
+
   if (loading) {
     return <div>Loading node definitions...</div>;
   }
@@ -187,8 +200,9 @@ function App() {
         <nav className="top-navbar">
           <span className="navbar-title">FloatNodes</span>
           <div className="navbar-actions">
+            <NewGraphButton hasContent={nodes.length > 0 || edges.length > 0} onNew={handleNewGraph} />
             <ImportGraphButton onImport={handleImportGraph} />
-            <SaveGraphButton reactFlowInstance={reactFlowInstance} />
+            <SaveGraphButton reactFlowInstance={reactFlowInstance} fileHandleRef={saveFileHandleRef} />
             <ExportGraphButton reactFlowInstance={reactFlowInstance} />
           </div>
         </nav>

--- a/src/components/NodeNew.tsx
+++ b/src/components/NodeNew.tsx
@@ -1,0 +1,29 @@
+import '../styles/NodeExport.css';
+
+interface NodeNewProps {
+  hasContent: boolean;
+  onNew: () => void;
+}
+
+/**
+ * Button that clears the current graph and starts a fresh canvas.
+ * Prompts for confirmation if the canvas isn't already empty so the
+ * designer doesn't lose unsaved work by accident.
+ */
+export function NewGraphButton({ hasContent, onNew }: NodeNewProps) {
+  const handleClick = () => {
+    if (hasContent) {
+      const confirmed = window.confirm(
+        'Discard the current graph and start a new blank canvas? Any unsaved changes will be lost.'
+      );
+      if (!confirmed) return;
+    }
+    onNew();
+  };
+
+  return (
+    <button className="graph-action-button" onClick={handleClick}>
+      New
+    </button>
+  );
+}

--- a/src/components/NodeSave.tsx
+++ b/src/components/NodeSave.tsx
@@ -1,9 +1,16 @@
 import { useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
 import type { Node, Edge, ReactFlowInstance } from 'reactflow';
 import '../styles/NodeExport.css';
 
 interface SaveGraphProps {
   reactFlowInstance: ReactFlowInstance<Node, Edge>;
+  /**
+   * Optional external ref for the save file handle. Lifting this up to the
+   * parent lets other actions (e.g. "New Canvas") reset it so the next Save
+   * re-prompts for a file location.
+   */
+  fileHandleRef?: MutableRefObject<FileSystemFileHandle | null>;
 }
 
 function getCleanGraph(reactFlowInstance: ReactFlowInstance) {
@@ -17,8 +24,12 @@ function getCleanGraph(reactFlowInstance: ReactFlowInstance) {
   return JSON.stringify({ nodes: cleanNodes, edges }, null, 2);
 }
 
-export function SaveGraphButton({ reactFlowInstance }: SaveGraphProps) {
-  const fileHandleRef = useRef<FileSystemFileHandle | null>(null);
+export function SaveGraphButton({ reactFlowInstance, fileHandleRef: externalRef }: SaveGraphProps) {
+  const internalRef = useRef<FileSystemFileHandle | null>(null);
+  // Prefer the parent-provided ref if one was passed; otherwise fall back to
+  // our own. This lets App.tsx reset the handle (e.g. from "New Canvas")
+  // without SaveGraphButton having to re-render to pick up a new value.
+  const fileHandleRef = externalRef ?? internalRef;
   const [status, setStatus] = useState<'idle' | 'saved'>('idle');
 
   const handleSave = async () => {


### PR DESCRIPTION
Add New Canvas button that clears graph and resets save handle

- NodeNew.tsx: new button with confirm dialog when canvas has content
- App.tsx: lifts save file handle ref up so New can reset it
- NodeSave.tsx: accepts optional external fileHandleRef prop

Matches the Word "New → next Save prompts for file location" behavior:
fresh canvas = fresh file, previously-picked save location is forgotten.