### PR TITLE
Enforce single connection per input handle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,14 @@ function App() {
   }, [definitions]);
 
   const onConnect = useCallback(
-    (params: Connection) => setEdges((eds) => addEdge(params, eds)),
+    (params: Connection) =>
+      setEdges((eds) => {
+        const filtered = eds.filter(
+          (e) =>
+            !(e.target === params.target && e.targetHandle === params.targetHandle)
+        );
+        return addEdge(params, filtered);
+      }),
     [setEdges]
   );
 


### PR DESCRIPTION
Dragging a new wire onto a connected input detaches the previous one.