### PR TITLE
Add undo/redo, comments, groups, and canvas UX pass

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,18 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
   type Node,
   type Edge,
   type Connection,
+  type NodeChange,
+  type EdgeChange,
+  type NodeProps,
+  type NodeDragHandler,
   addEdge,
-  useNodesState,
-  useEdgesState,
+  applyNodeChanges,
+  applyEdgeChanges,
   Controls,
   Background,
+  SelectionMode,
   useReactFlow,
   type NodeMouseHandler
 } from 'reactflow';
@@ -21,51 +26,82 @@ import { OpenGraphButton } from './components/NodeOpen';
 import { SaveGraphButton } from './components/NodeSave';
 import { SaveAsGraphButton } from './components/NodeSaveAs';
 import { GenericNode } from './components/nodes/GenericNode';
+import { CommentNode } from './components/nodes/CommentNode';
+import { GroupNode } from './components/nodes/GroupNode';
 import { Inspector } from './components/Inspector';
+import { useHistoryState } from './hooks/useHistoryState';
+
+type Clipboard = { nodes: Node[]; edges: Edge[] } | null;
 
 function App() {
   const { definitions, loading, error } = useNodeDefinitions();
-  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const { nodes, edges, setNodes, setEdges, pushHistory, undo, redo, resetHistory } = useHistoryState();
   const reactFlowInstance = useReactFlow();
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
-  // Shared file handle for Save — lifted here so "New" can reset it,
-  // matching the Word "New → Save prompts again" behavior.
   const saveFileHandleRef = useRef<FileSystemFileHandle | null>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const clipboardRef = useRef<Clipboard>(null);
+  // Track latest mouse position over the canvas (for paste-at-cursor).
+  const mousePosRef = useRef<{ x: number; y: number } | null>(null);
 
-  // Build nodeTypes map dynamically from definitions — every type uses GenericNode
+  // Build nodeTypes map dynamically from definitions; comment & group are built-in.
   const nodeTypes = useMemo(() => {
-    if (!definitions) return {};
-    const types: Record<string, typeof GenericNode> = {};
-    for (const def of definitions.nodeTypes) {
-      types[def.id] = GenericNode;
+    const types: Record<string, React.ComponentType<NodeProps>> = {
+      comment: CommentNode,
+      group: GroupNode,
+    };
+    if (definitions) {
+      for (const def of definitions.nodeTypes) {
+        types[def.id] = GenericNode;
+      }
     }
     return types;
   }, [definitions]);
 
-  const onConnect = useCallback(
-    (params: Connection) =>
-      setEdges((eds) => {
-        const filtered = eds.filter(
-          (e) =>
-            !(e.target === params.target && e.targetHandle === params.targetHandle)
-        );
-        return addEdge(params, filtered);
-      }),
-    [setEdges]
-  );
+  // ── Mutation handlers ──────────────────────────────────────────────
+  const handleNodeDataChange = useCallback((
+    nodeId: string,
+    field: string,
+    value: number | number[] | string
+  ) => {
+    pushHistory();
+    setNodes((curr) =>
+      curr.map((node) =>
+        node.id === nodeId ? { ...node, data: { ...node.data, [field]: value } } : node
+      )
+    );
+    setSelectedNode((prev) =>
+      prev?.id === nodeId ? { ...prev, data: { ...prev.data, [field]: value } } : prev
+    );
+  }, [pushHistory, setNodes]);
+
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
+    // Snapshot before destructive changes only.
+    if (changes.some((c) => c.type === 'remove')) pushHistory();
+    setNodes((curr) => applyNodeChanges(changes, curr));
+  }, [pushHistory, setNodes]);
+
+  const onEdgesChange = useCallback((changes: EdgeChange[]) => {
+    if (changes.some((c) => c.type === 'remove')) pushHistory();
+    setEdges((curr) => applyEdgeChanges(changes, curr));
+  }, [pushHistory, setEdges]);
+
+  const onConnect = useCallback((params: Connection) => {
+    pushHistory();
+    setEdges((eds) => {
+      const filtered = eds.filter(
+        (e) => !(e.target === params.target && e.targetHandle === params.targetHandle)
+      );
+      return addEdge(params, filtered);
+    });
+  }, [pushHistory, setEdges]);
 
   const onNodeClick: NodeMouseHandler = useCallback((_event, node) => {
     setSelectedNode(node);
   }, []);
 
-  const onPaneClick = useCallback(() => {
-    setSelectedNode(null);
-  }, []);
-
-  const closeInspector = useCallback(() => {
-    setSelectedNode(null);
-  }, []);
+  const onPaneClick = useCallback(() => setSelectedNode(null), []);
+  const closeInspector = useCallback(() => setSelectedNode(null), []);
 
   const onNodesDelete = useCallback((deleted: Node[]) => {
     setSelectedNode((prev) =>
@@ -73,124 +109,316 @@ function App() {
     );
   }, []);
 
-  const handleNodeDataChange = useCallback((
-    nodeId: string,
-    field: string,
-    value: number | number[] | string
-  ) => {
-    setNodes((nodes) =>
-      nodes.map((node) => {
-        if (node.id === nodeId) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              [field]: value
-            }
-          };
-        }
-        return node;
-      })
-    );
-
-    setSelectedNode((prev) => {
-      if (prev?.id === nodeId) {
-        return {
-          ...prev,
-          data: { ...prev.data, [field]: value }
-        };
-      }
-      return prev;
+  // ── Add node (spawns at viewport center) ───────────────────────────
+  const viewportCenter = useCallback(() => {
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect) return { x: 200, y: 200 };
+    return reactFlowInstance.screenToFlowPosition({
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
     });
+  }, [reactFlowInstance]);
+
+  const flashNode = useCallback((nodeId: string) => {
+    setTimeout(() => {
+      setNodes((nds) => nds.map((n) =>
+        n.id === nodeId ? { ...n, data: { ...n.data, highlightClass: 'node-just-added-fade' } } : n
+      ));
+    }, 600);
+    setTimeout(() => {
+      setNodes((nds) => nds.map((n) =>
+        n.id === nodeId ? { ...n, data: { ...n.data, highlightClass: undefined } } : n
+      ));
+    }, 2100);
   }, [setNodes]);
 
   const handleAddNode = useCallback((nodeTypeId: string) => {
     if (!definitions) return;
-
     const definition = getNodeDefinition(definitions, nodeTypeId);
     if (!definition) return;
 
     const data: Record<string, unknown> = {
       label: definition.title,
       onChange: handleNodeDataChange,
+      highlightClass: 'node-just-added',
     };
-
-    definition.parameters.forEach(param => {
+    definition.parameters.forEach((param) => {
       data[param.name] = param.default;
     });
 
+    // Center the node on the viewport center (offset by approx half its size).
+    const center = viewportCenter();
     const nodeId = `node-${Date.now()}`;
-    data.highlightClass = 'node-just-added';
-
     const newNode: Node = {
       id: nodeId,
       type: nodeTypeId,
-      position: {
-        x: Math.random() * 400 + 100,
-        y: Math.random() * 400 + 100
-      },
+      position: { x: center.x - 100, y: center.y - 40 },
       data,
     };
 
+    pushHistory();
     setNodes((nds) => [...nds, newNode]);
+    flashNode(nodeId);
+  }, [definitions, handleNodeDataChange, viewportCenter, pushHistory, setNodes, flashNode]);
 
-    // Auto-pan viewport to center on the newly created node
-    setTimeout(() => {
-      reactFlowInstance.setCenter(
-        newNode.position.x + 75,
-        newNode.position.y + 50,
-        { zoom: reactFlowInstance.getZoom(), duration: 300 }
-      );
-    }, 50);
+  const handleAddComment = useCallback(() => {
+    const center = viewportCenter();
+    const nodeId = `comment-${Date.now()}`;
+    const newNode: Node = {
+      id: nodeId,
+      type: 'comment',
+      position: { x: center.x - 100, y: center.y - 40 },
+      data: {
+        text: '',
+        onChange: handleNodeDataChange,
+        highlightClass: 'node-just-added',
+      },
+    };
+    pushHistory();
+    setNodes((nds) => [...nds, newNode]);
+    flashNode(nodeId);
+  }, [viewportCenter, handleNodeDataChange, pushHistory, setNodes, flashNode]);
 
-    // Fade out the highlight after a short delay
-    setTimeout(() => {
-      setNodes((nds) =>
-        nds.map((n) =>
-          n.id === nodeId
-            ? { ...n, data: { ...n.data, highlightClass: 'node-just-added-fade' } }
-            : n
-        )
-      );
-    }, 600);
+  // ── Group / Ungroup (frame-style: no reparenting) ─────────────────
+  // A "group" is a translucent rectangle that lives BEHIND other nodes.
+  // Children aren't reparented; dragging the group moves whatever currently
+  // sits inside its world-space bounds (computed at drag start).
+  const groupSelected = useCallback(() => {
+    const selected = nodes.filter((n) => n.selected && n.type !== 'group');
+    if (selected.length < 2) return;
 
-    // Remove the class entirely after the fade completes
-    setTimeout(() => {
-      setNodes((nds) =>
-        nds.map((n) =>
-          n.id === nodeId
-            ? { ...n, data: { ...n.data, highlightClass: undefined } }
-            : n
-        )
-      );
-    }, 2100);
-  }, [definitions, setNodes, handleNodeDataChange, reactFlowInstance]);
+    const PAD = 40;
+    const HEADER = 36;
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const n of selected) {
+      const w = (n.width ?? 200);
+      const h = (n.height ?? 80);
+      minX = Math.min(minX, n.position.x);
+      minY = Math.min(minY, n.position.y);
+      maxX = Math.max(maxX, n.position.x + w);
+      maxY = Math.max(maxY, n.position.y + h);
+    }
+    const groupId = `group-${Date.now()}`;
+    const groupX = minX - PAD;
+    const groupY = minY - PAD - HEADER;
+    const groupW = (maxX - minX) + PAD * 2;
+    const groupH = (maxY - minY) + PAD * 2 + HEADER;
 
+    const groupNode: Node = {
+      id: groupId,
+      type: 'group',
+      position: { x: groupX, y: groupY },
+      data: {
+        label: 'Group',
+        width: groupW,
+        height: groupH,
+        onChange: handleNodeDataChange,
+      },
+      style: { width: groupW, height: groupH },
+      // Render behind real nodes so wires stay clickable.
+      zIndex: -1,
+      selectable: true,
+      draggable: true,
+    };
+
+    pushHistory();
+    // Prepend the group so it renders first (lowest in z-order).
+    setNodes((curr) => [groupNode, ...curr.map((n) => ({ ...n, selected: false }))]);
+  }, [nodes, handleNodeDataChange, pushHistory, setNodes]);
+
+  const ungroupSelected = useCallback(() => {
+    const selectedGroupIds = new Set(
+      nodes.filter((n) => n.selected && n.type === 'group').map((g) => g.id)
+    );
+    if (selectedGroupIds.size === 0) return;
+    pushHistory();
+    setNodes((curr) => curr.filter((n) => !selectedGroupIds.has(n.id)));
+  }, [nodes, pushHistory, setNodes]);
+
+  // When a group node starts dragging, capture the IDs of every other node
+  // currently inside its bounds. Those nodes get translated by the same delta
+  // on each drag tick, then forgotten on drag stop.
+  const groupDragContextRef = useRef<{
+    groupId: string;
+    startGroupPos: { x: number; y: number };
+    children: { id: string; startPos: { x: number; y: number } }[];
+  } | null>(null);
+
+  const handleNodeDragStart: NodeDragHandler = useCallback((_e, node) => {
+    pushHistory();
+    if (node.type !== 'group') {
+      groupDragContextRef.current = null;
+      return;
+    }
+    const gx = node.position.x;
+    const gy = node.position.y;
+    const gw = ((node.data as { width?: number })?.width) ?? (node.style?.width as number) ?? 320;
+    const gh = ((node.data as { height?: number })?.height) ?? (node.style?.height as number) ?? 220;
+    const inside = nodes.filter((n) => {
+      if (n.id === node.id) return false;
+      if (n.type === 'group') return false;
+      const nx = n.position.x;
+      const ny = n.position.y;
+      const nw = n.width ?? 200;
+      const nh = n.height ?? 80;
+      // Treat a node as "inside" if its center is within the group bounds.
+      const cx = nx + nw / 2;
+      const cy = ny + nh / 2;
+      return cx >= gx && cx <= gx + gw && cy >= gy && cy <= gy + gh;
+    });
+    groupDragContextRef.current = {
+      groupId: node.id,
+      startGroupPos: { x: gx, y: gy },
+      children: inside.map((n) => ({ id: n.id, startPos: { x: n.position.x, y: n.position.y } })),
+    };
+  }, [nodes, pushHistory]);
+
+  const handleNodeDrag: NodeDragHandler = useCallback((_e, node) => {
+    const ctx = groupDragContextRef.current;
+    if (!ctx || ctx.groupId !== node.id) return;
+    const dx = node.position.x - ctx.startGroupPos.x;
+    const dy = node.position.y - ctx.startGroupPos.y;
+    const childMap = new Map(ctx.children.map((c) => [c.id, c.startPos]));
+    setNodes((curr) =>
+      curr.map((n) => {
+        const start = childMap.get(n.id);
+        if (!start) return n;
+        return { ...n, position: { x: start.x + dx, y: start.y + dy } };
+      })
+    );
+  }, [setNodes]);
+
+  const handleNodeDragStop: NodeDragHandler = useCallback(() => {
+    groupDragContextRef.current = null;
+  }, []);
+
+  // ── Copy / Paste ───────────────────────────────────────────────────
+  const copySelection = useCallback(() => {
+    const selectedNodes = nodes.filter((n) => n.selected);
+    if (selectedNodes.length === 0) return;
+    const selectedIds = new Set(selectedNodes.map((n) => n.id));
+    const selectedEdges = edges.filter(
+      (e) => selectedIds.has(e.source) && selectedIds.has(e.target)
+    );
+    // Deep-clone but strip non-serializable bits (onChange) — re-added at paste.
+    clipboardRef.current = {
+      nodes: selectedNodes.map((n) => {
+        const cleanData = { ...(n.data as Record<string, unknown>) };
+        delete cleanData.onChange;
+        delete cleanData.highlightClass;
+        return { ...n, data: cleanData, selected: false } as Node;
+      }),
+      edges: selectedEdges.map((e) => ({ ...e, selected: false })),
+    };
+  }, [nodes, edges]);
+
+  const pasteClipboard = useCallback(() => {
+    const clip = clipboardRef.current;
+    if (!clip || clip.nodes.length === 0) return;
+
+    // Determine paste anchor: cursor position if known, else viewport center
+    // (with a small offset so pasted nodes don't sit exactly on top of the originals).
+    let anchor: { x: number; y: number };
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (mousePosRef.current && rect) {
+      anchor = reactFlowInstance.screenToFlowPosition({
+        x: mousePosRef.current.x,
+        y: mousePosRef.current.y,
+      });
+    } else {
+      const c = viewportCenter();
+      anchor = { x: c.x + 40, y: c.y + 40 };
+    }
+
+    // Compute the top-left of the copied selection so we can offset to anchor.
+    let minX = Infinity, minY = Infinity;
+    for (const n of clip.nodes) {
+      if (!n.parentNode) {
+        minX = Math.min(minX, n.position.x);
+        minY = Math.min(minY, n.position.y);
+      }
+    }
+    if (!isFinite(minX)) { minX = 0; minY = 0; }
+
+    const idMap = new Map<string, string>();
+    const stamp = Date.now();
+    clip.nodes.forEach((n, i) => idMap.set(n.id, `paste-${stamp}-${i}`));
+
+    const newNodes: Node[] = clip.nodes.map((n) => {
+      const newId = idMap.get(n.id)!;
+      const newParent = n.parentNode ? idMap.get(n.parentNode) : undefined;
+      const basePos = newParent
+        ? n.position // child positions are parent-relative, keep them
+        : { x: anchor.x + (n.position.x - minX), y: anchor.y + (n.position.y - minY) };
+      return {
+        ...n,
+        id: newId,
+        parentNode: newParent,
+        position: basePos,
+        selected: true,
+        data: { ...n.data, onChange: handleNodeDataChange },
+      };
+    });
+
+    const newEdges: Edge[] = clip.edges.map((e, i) => ({
+      ...e,
+      id: `paste-edge-${stamp}-${i}`,
+      source: idMap.get(e.source) ?? e.source,
+      target: idMap.get(e.target) ?? e.target,
+      selected: true,
+    }));
+
+    pushHistory();
+    setNodes((curr) => curr.map((n) => ({ ...n, selected: false })).concat(newNodes));
+    setEdges((curr) => curr.map((e) => ({ ...e, selected: false })).concat(newEdges));
+  }, [reactFlowInstance, viewportCenter, handleNodeDataChange, pushHistory, setNodes, setEdges]);
+
+  // ── Keyboard shortcuts ─────────────────────────────────────────────
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      // Skip when typing in an input/textarea (let the field handle it).
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+        return;
+      }
+      const meta = e.metaKey || e.ctrlKey;
+      if (!meta) return;
+
+      const key = e.key.toLowerCase();
+      if (key === 'z' && !e.shiftKey) { e.preventDefault(); undo(); return; }
+      if ((key === 'z' && e.shiftKey) || key === 'y') { e.preventDefault(); redo(); return; }
+      if (key === 'c') { e.preventDefault(); copySelection(); return; }
+      if (key === 'v') { e.preventDefault(); pasteClipboard(); return; }
+      if (key === 'g' && !e.shiftKey) { e.preventDefault(); groupSelected(); return; }
+      if (key === 'g' && e.shiftKey) { e.preventDefault(); ungroupSelected(); return; }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [undo, redo, copySelection, pasteClipboard, groupSelected, ungroupSelected]);
+
+  // Track mouse so paste can drop at the cursor.
+  const onPaneMouseMove = useCallback((e: React.MouseEvent) => {
+    mousePosRef.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  // ── Open / New ─────────────────────────────────────────────────────
   const handleOpenGraph = useCallback((
     openedNodes: Node[],
     openedEdges: Edge[]
   ) => {
     const nodesWithCallbacks = openedNodes.map((node) => ({
       ...node,
-      data: {
-        ...node.data,
-        onChange: handleNodeDataChange,
-      }
+      data: { ...node.data, onChange: handleNodeDataChange },
     }));
-
-    setNodes(nodesWithCallbacks);
-    setEdges(openedEdges);
+    resetHistory(nodesWithCallbacks, openedEdges);
     setSelectedNode(null);
-  }, [setNodes, setEdges, handleNodeDataChange]);
+  }, [resetHistory, handleNodeDataChange]);
 
   const handleNewGraph = useCallback(() => {
-    setNodes([]);
-    setEdges([]);
+    resetHistory([], []);
     setSelectedNode(null);
-    // Forget the previously-picked save location so the next Save opens the
-    // file picker again (fresh canvas = fresh file).
     saveFileHandleRef.current = null;
-  }, [setNodes, setEdges]);
+  }, [resetHistory]);
 
   if (loading) {
     return <div>Loading node definitions...</div>;
@@ -203,14 +431,40 @@ function App() {
   return (
     <NodeDefinitionsContext.Provider value={definitions}>
       <div className="app-root">
-        {/* Top Navbar */}
+        {/* Top Navbar — File ops left · Edit center · Insert right */}
         <nav className="top-navbar">
-          <span className="navbar-title">FloatNodes</span>
-          <div className="navbar-actions">
+          <div className="navbar-section navbar-section-left">
+            <span className="navbar-title">FloatNodes</span>
+            <span className="navbar-divider" />
             <NewGraphButton hasContent={nodes.length > 0 || edges.length > 0} onNew={handleNewGraph} />
             <OpenGraphButton onOpen={handleOpenGraph} fileHandleRef={saveFileHandleRef} />
             <SaveGraphButton reactFlowInstance={reactFlowInstance} fileHandleRef={saveFileHandleRef} />
             <SaveAsGraphButton reactFlowInstance={reactFlowInstance} fileHandleRef={saveFileHandleRef} />
+          </div>
+
+          <div className="navbar-section navbar-section-center">
+            <button
+              className="graph-action-button icon-button"
+              onClick={undo}
+              title="Undo (Ctrl/Cmd+Z)"
+              aria-label="Undo"
+            >↶</button>
+            <button
+              className="graph-action-button icon-button"
+              onClick={redo}
+              title="Redo (Ctrl/Cmd+Shift+Z)"
+              aria-label="Redo"
+            >↷</button>
+          </div>
+
+          <div className="navbar-section navbar-section-right">
+            <button
+              className="graph-action-button"
+              onClick={handleAddComment}
+              title="Add comment (sticky note)"
+            >
+              + Comment
+            </button>
           </div>
         </nav>
 
@@ -219,10 +473,21 @@ function App() {
           <div className="editor-sidebar">
             <div className="editor-sidebar-title">Node Catalog</div>
             <NodeCatalog definitions={definitions} onAddNode={handleAddNode} />
+            <div className="shortcut-hint">
+              <div className="shortcut-hint-title">Shortcuts</div>
+              <div>Drag pane: box-select (touch = include)</div>
+              <div>Space + drag: pan canvas</div>
+              <div>Two-finger scroll: pan</div>
+              <div>Ctrl/Cmd+C / V: copy / paste</div>
+              <div>Ctrl/Cmd+Z: undo</div>
+              <div>Ctrl/Cmd+Shift+Z: redo</div>
+              <div>Ctrl/Cmd+G: group selection</div>
+              <div>Ctrl/Cmd+Shift+G: ungroup</div>
+            </div>
           </div>
 
-          <div className="editor-canvas">
-            <div className="editor-canvas-inner">
+          <div className="editor-canvas" ref={canvasRef}>
+            <div className="editor-canvas-inner" onMouseMove={onPaneMouseMove}>
               <ReactFlow
                 nodes={nodes}
                 nodeTypes={nodeTypes}
@@ -231,8 +496,20 @@ function App() {
                 onEdgesChange={onEdgesChange}
                 onConnect={onConnect}
                 onNodeClick={onNodeClick}
+                onNodeDragStart={handleNodeDragStart}
+                onNodeDrag={handleNodeDrag}
+                onNodeDragStop={handleNodeDragStop}
                 onPaneClick={onPaneClick}
                 onNodesDelete={onNodesDelete}
+                selectionOnDrag
+                selectionMode={SelectionMode.Partial}
+                panOnDrag={[1, 2]}
+                panActivationKeyCode="Space"
+                panOnScroll
+                zoomOnScroll={false}
+                zoomOnPinch
+                deleteKeyCode={['Backspace', 'Delete']}
+                multiSelectionKeyCode={['Meta', 'Control', 'Shift']}
               >
                 <Controls position="top-right" />
                 <Background />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -369,8 +369,8 @@ function App() {
     }));
 
     pushHistory();
-    setNodes((curr) => curr.map((n) => ({ ...n, selected: false })).concat(newNodes));
-    setEdges((curr) => curr.map((e) => ({ ...e, selected: false })).concat(newEdges));
+    setNodes((curr) => [...curr.map((n) => ({ ...n, selected: false })), ...newNodes]);
+    setEdges((curr) => [...curr.map((e) => ({ ...e, selected: false })), ...newEdges]);
   }, [reactFlowInstance, viewportCenter, handleNodeDataChange, pushHistory, setNodes, setEdges]);
 
   // ── Keyboard shortcuts ─────────────────────────────────────────────

--- a/src/components/NodeOpen.tsx
+++ b/src/components/NodeOpen.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import type { MutableRefObject } from 'react';
 import type { Node, Edge } from 'reactflow';
+import { deserializeGraph } from '../utilities/serializeGraph';
 import '../styles/NodeExport.css';
 
 interface NodeOpenProps {
@@ -8,15 +9,7 @@ interface NodeOpenProps {
   fileHandleRef: MutableRefObject<FileSystemFileHandle | null>;
 }
 
-function parseGraph(text: string): { nodes: Node[]; edges: Edge[] } | null {
-  try {
-    const json = JSON.parse(text);
-    if (!Array.isArray(json.nodes) || !Array.isArray(json.edges)) return null;
-    return { nodes: json.nodes, edges: json.edges };
-  } catch {
-    return null;
-  }
-}
+const parseGraph = deserializeGraph;
 
 export function OpenGraphButton({ onOpen, fileHandleRef }: NodeOpenProps) {
   const fallbackInputRef = useRef<HTMLInputElement>(null);

--- a/src/components/NodeSave.tsx
+++ b/src/components/NodeSave.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import type { MutableRefObject } from 'react';
 import type { Node, Edge, ReactFlowInstance } from 'reactflow';
+import { serializeGraph } from '../utilities/serializeGraph';
 import '../styles/NodeExport.css';
 
 interface SaveGraphProps {
@@ -15,13 +16,7 @@ interface SaveGraphProps {
 
 function getCleanGraph(reactFlowInstance: ReactFlowInstance) {
   const { nodes, edges } = reactFlowInstance.toObject();
-  const cleanNodes = nodes.map((node) => ({
-    ...node,
-    data: Object.fromEntries(
-      Object.entries(node.data).filter(([, v]) => typeof v !== 'function')
-    ),
-  }));
-  return JSON.stringify({ nodes: cleanNodes, edges }, null, 2);
+  return serializeGraph(nodes, edges);
 }
 
 export function SaveGraphButton({ reactFlowInstance, fileHandleRef: externalRef }: SaveGraphProps) {

--- a/src/components/NodeSaveAs.tsx
+++ b/src/components/NodeSaveAs.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { MutableRefObject } from 'react';
 import type { Node, Edge, ReactFlowInstance } from 'reactflow';
+import { serializeGraph } from '../utilities/serializeGraph';
 import '../styles/NodeExport.css';
 
 interface SaveAsGraphProps {
@@ -10,13 +11,7 @@ interface SaveAsGraphProps {
 
 function getCleanGraph(reactFlowInstance: ReactFlowInstance) {
   const { nodes, edges } = reactFlowInstance.toObject();
-  const cleanNodes = nodes.map((node) => ({
-    ...node,
-    data: Object.fromEntries(
-      Object.entries(node.data).filter(([, v]) => typeof v !== 'function')
-    ),
-  }));
-  return JSON.stringify({ nodes: cleanNodes, edges }, null, 2);
+  return serializeGraph(nodes, edges);
 }
 
 export function SaveAsGraphButton({ reactFlowInstance, fileHandleRef }: SaveAsGraphProps) {

--- a/src/components/nodes/CommentNode.tsx
+++ b/src/components/nodes/CommentNode.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react';
+import type { NodeProps } from 'reactflow';
+
+interface CommentData {
+  text?: string;
+  onChange?: (id: string, field: string, value: string | number | number[]) => void;
+  highlightClass?: string;
+}
+
+export function CommentNode({ id, data }: NodeProps<CommentData>) {
+  const [editing, setEditing] = useState(false);
+  const [local, setLocal] = useState(data.text ?? '');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (!editing) setLocal(data.text ?? '');
+  }, [data.text, editing]);
+
+  useEffect(() => {
+    if (editing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.select();
+    }
+  }, [editing]);
+
+  const commit = () => {
+    setEditing(false);
+    if (local !== (data.text ?? '')) data.onChange?.(id, 'text', local);
+  };
+
+  return (
+    <div
+      className={`comment-node ${data.highlightClass ?? ''}`}
+      onDoubleClick={() => setEditing(true)}
+    >
+      {editing ? (
+        <textarea
+          ref={textareaRef}
+          className="comment-textarea nodrag"
+          value={local}
+          onChange={(e) => setLocal(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              setLocal(data.text ?? '');
+              setEditing(false);
+            }
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) commit();
+          }}
+          placeholder="Type a comment..."
+        />
+      ) : (
+        <div className="comment-text">
+          {data.text ? data.text : <span className="comment-placeholder">Double-click to edit</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/nodes/GroupNode.tsx
+++ b/src/components/nodes/GroupNode.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+import type { NodeProps } from 'reactflow';
+
+interface GroupData {
+  label?: string;
+  width?: number;
+  height?: number;
+  onChange?: (id: string, field: string, value: string | number | number[]) => void;
+  highlightClass?: string;
+}
+
+export function GroupNode({ id, data }: NodeProps<GroupData>) {
+  const [editing, setEditing] = useState(false);
+  const [local, setLocal] = useState(data.label ?? 'Group');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!editing) setLocal(data.label ?? 'Group');
+  }, [data.label, editing]);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const commit = () => {
+    setEditing(false);
+    if (local !== (data.label ?? 'Group')) data.onChange?.(id, 'label', local);
+  };
+
+  const width = data.width ?? 320;
+  const height = data.height ?? 220;
+
+  return (
+    <div
+      className={`group-node ${data.highlightClass ?? ''}`}
+      style={{ width, height }}
+    >
+      <div className="group-header" onDoubleClick={() => setEditing(true)}>
+        {editing ? (
+          <input
+            ref={inputRef}
+            className="group-label-input nodrag"
+            value={local}
+            onChange={(e) => setLocal(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commit();
+              if (e.key === 'Escape') {
+                setLocal(data.label ?? 'Group');
+                setEditing(false);
+              }
+            }}
+          />
+        ) : (
+          <span className="group-label">{data.label ?? 'Group'}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useHistoryState.ts
+++ b/src/hooks/useHistoryState.ts
@@ -1,0 +1,56 @@
+import { useCallback, useRef, useState } from 'react';
+import type { Edge, Node } from 'reactflow';
+
+type Snapshot = { nodes: Node[]; edges: Edge[] };
+
+const MAX_HISTORY = 100;
+
+/**
+ * Undo/redo for a (nodes, edges) pair. Callers explicitly call `pushHistory`
+ * before any committable mutation; transient changes (live drag, selection)
+ * skip the snapshot.
+ */
+export function useHistoryState(initialNodes: Node[] = [], initialEdges: Edge[] = []) {
+  const [nodes, setNodes] = useState<Node[]>(initialNodes);
+  const [edges, setEdges] = useState<Edge[]>(initialEdges);
+  const past = useRef<Snapshot[]>([]);
+  const future = useRef<Snapshot[]>([]);
+  // Refs mirror state so pushHistory captures the latest snapshot without re-binding.
+  const nodesRef = useRef(nodes);
+  const edgesRef = useRef(edges);
+  nodesRef.current = nodes;
+  edgesRef.current = edges;
+
+  const pushHistory = useCallback(() => {
+    past.current.push({ nodes: nodesRef.current, edges: edgesRef.current });
+    if (past.current.length > MAX_HISTORY) past.current.shift();
+    future.current = [];
+  }, []);
+
+  const undo = useCallback(() => {
+    if (past.current.length === 0) return false;
+    const prev = past.current.pop()!;
+    future.current.push({ nodes: nodesRef.current, edges: edgesRef.current });
+    setNodes(prev.nodes);
+    setEdges(prev.edges);
+    return true;
+  }, []);
+
+  const redo = useCallback(() => {
+    if (future.current.length === 0) return false;
+    const next = future.current.pop()!;
+    past.current.push({ nodes: nodesRef.current, edges: edgesRef.current });
+    setNodes(next.nodes);
+    setEdges(next.edges);
+    return true;
+  }, []);
+
+  const resetHistory = useCallback((newNodes: Node[], newEdges: Edge[]) => {
+    past.current = [];
+    future.current = [];
+    setNodes(newNodes);
+    setEdges(newEdges);
+  }, []);
+
+  return { nodes, edges, setNodes, setEdges, pushHistory, undo, redo, resetHistory };
+}

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -10,9 +10,9 @@
 
 /* ── Top Navbar ── */
 .top-navbar {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
   padding: 0.6rem 1.25rem;
   background: rgba(28, 28, 30, 0.85);
   backdrop-filter: blur(20px);
@@ -22,11 +22,35 @@
   z-index: 10;
 }
 
+.navbar-section {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.navbar-section-left { justify-self: start; }
+.navbar-section-center { justify-self: center; }
+.navbar-section-right { justify-self: end; }
+
 .navbar-title {
   font-size: 1rem;
   font-weight: 600;
   color: #f5f5f7;
   letter-spacing: -0.01em;
+}
+
+.navbar-divider {
+  width: 1px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.12);
+  margin: 0 0.4rem;
+}
+
+.icon-button {
+  min-width: 36px;
+  text-align: center;
+  font-size: 1rem;
+  line-height: 1;
 }
 
 .navbar-actions {
@@ -319,4 +343,140 @@
 /* ── ReactFlow background override ── */
 .react-flow__background {
   background: #1c1c1e !important;
+}
+
+/* ══════════════════════════════════════
+   Comment node (sticky note)
+   ══════════════════════════════════════ */
+.comment-node {
+  min-width: 200px;
+  min-height: 80px;
+  max-width: 320px;
+  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  background: rgba(255, 213, 79, 0.92);
+  color: #1c1c1e;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  white-space: pre-wrap;
+  word-break: break-word;
+  cursor: grab;
+  transition: box-shadow 200ms ease;
+}
+
+.comment-node:hover {
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.38);
+}
+
+.comment-node.node-just-added {
+  box-shadow: 0 0 0 2px #5ce0d6, 0 0 24px rgba(92, 224, 214, 0.4);
+}
+
+.comment-text {
+  width: 100%;
+  height: 100%;
+  min-height: 60px;
+}
+
+.comment-placeholder {
+  color: rgba(28, 28, 30, 0.45);
+  font-style: italic;
+}
+
+.comment-textarea {
+  width: 100%;
+  min-height: 60px;
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: vertical;
+  font: inherit;
+  color: inherit;
+}
+
+/* ══════════════════════════════════════
+   Group container node
+   ══════════════════════════════════════ */
+.group-node {
+  border-radius: 16px;
+  background: rgba(92, 224, 214, 0.06);
+  border: 1.5px dashed rgba(92, 224, 214, 0.5);
+  box-shadow: inset 0 0 32px rgba(92, 224, 214, 0.05);
+  position: relative;
+  pointer-events: all;
+}
+
+.group-node.node-just-added {
+  box-shadow: 0 0 0 2px #5ce0d6, 0 0 24px rgba(92, 224, 214, 0.4);
+}
+
+.group-header {
+  position: absolute;
+  top: 8px;
+  left: 12px;
+  right: 12px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  pointer-events: all;
+}
+
+.group-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #5ce0d6;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: text;
+  user-select: none;
+}
+
+.group-label-input {
+  background: rgba(28, 28, 30, 0.85);
+  border: 1px solid rgba(92, 224, 214, 0.5);
+  border-radius: 6px;
+  padding: 0.15rem 0.5rem;
+  color: #5ce0d6;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  outline: none;
+  width: 180px;
+}
+
+/* Selected highlight (also applies to comments/groups) */
+.react-flow__node.selected .comment-node,
+.react-flow__node.selected .group-node,
+.react-flow__node.selected .node {
+  box-shadow: 0 0 0 2px rgba(10, 132, 255, 0.8), 0 4px 24px rgba(0, 0, 0, 0.3);
+}
+
+/* ══════════════════════════════════════
+   Sidebar shortcut hint
+   ══════════════════════════════════════ */
+.shortcut-hint {
+  margin-top: 1.25rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.68rem;
+  color: #8e8e93;
+  line-height: 1.6;
+}
+
+.shortcut-hint-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #636366;
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+}
+
+/* Selection box styling */
+.react-flow__selection {
+  background: rgba(10, 132, 255, 0.08) !important;
+  border: 1px solid rgba(10, 132, 255, 0.6) !important;
 }

--- a/src/utilities/serializeGraph.ts
+++ b/src/utilities/serializeGraph.ts
@@ -1,0 +1,56 @@
+import type { Edge, Node } from 'reactflow';
+
+/**
+ * Option B graph format: comment/group nodes are split into a sibling
+ * `annotations` key so the `nodes`/`edges` arrays Unity reads stay pure
+ * (Unity's JsonUtility silently ignores unknown top-level keys).
+ */
+type SerializedGraph = {
+  nodes: Node[];
+  edges: Edge[];
+  annotations?: {
+    comments: Node[];
+    groups: Node[];
+  };
+};
+
+const isAnnotation = (n: Node) => n.type === 'comment' || n.type === 'group';
+
+const stripFunctions = (node: Node): Node => ({
+  ...node,
+  data: Object.fromEntries(
+    Object.entries(node.data ?? {}).filter(([, v]) => typeof v !== 'function')
+  ),
+});
+
+export function serializeGraph(nodes: Node[], edges: Edge[]): string {
+  const clean = nodes.map(stripFunctions);
+  const realNodes = clean.filter((n) => !isAnnotation(n));
+  const comments = clean.filter((n) => n.type === 'comment');
+  const groups = clean.filter((n) => n.type === 'group');
+
+  const payload: SerializedGraph = { nodes: realNodes, edges };
+  if (comments.length > 0 || groups.length > 0) {
+    payload.annotations = { comments, groups };
+  }
+  return JSON.stringify(payload, null, 2);
+}
+
+export function deserializeGraph(
+  text: string
+): { nodes: Node[]; edges: Edge[] } | null {
+  try {
+    const json = JSON.parse(text) as Partial<SerializedGraph>;
+    if (!Array.isArray(json.nodes) || !Array.isArray(json.edges)) return null;
+
+    const annotations = json.annotations;
+    const merged: Node[] = [
+      ...json.nodes,
+      ...(annotations?.comments ?? []),
+      ...(annotations?.groups ?? []),
+    ];
+    return { nodes: merged, edges: json.edges };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
- Undo/redo (Ctrl/Cmd+Z, Shift+Z) backed by a snapshot history hook
- Comment sticky-note node
- Frame-style group nodes (Ctrl/Cmd+G, Shift+G to ungroup) that drag contained nodes along
- Copy/paste of selected nodes + interior edges (Ctrl/Cmd+C / V), pastes at cursor or viewport center
- New nodes spawn at viewport center instead of a random position
- Partial-intersection box-select via left-drag (touch any pixel = include)
- Space+drag to pan; trackpad two-finger scroll pans the canvas
- Navbar reshuffle: File ops left, Undo/Redo center, + Comment right